### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## Prérequis
 
-- **Python 3.8+**
+- **Python 3.8 à 3.12**
 - **Bibliothèques nécessaires** :
   ```bash
   pip install pyqt5 yt-dlp simpleaudio pyttsx3


### PR DESCRIPTION
Corrige la version de Python. PyAudio ne fonctionne que jusqu'à Python 3.12.
[Source](https://www.reddit.com/r/learnpython/comments/1gk5p4z/im_using_python_latest_version_that_is_313_but/)